### PR TITLE
Update for 7.0.3

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -87,7 +87,7 @@ local S_TRANSMOGRIFIED       = "^" .. gsub(TRANSMOGRIFIED, "%%s", "(.+)")
 local S_UNIQUE_MULTIPLE      = topattern(ITEM_UNIQUE_MULTIPLE)
 local S_UPGRADE_LEVEL        = topattern(ITEM_UPGRADE_TOOLTIP_FORMAT)
 
-local TRADE_GOODS            = select(6, GetAuctionItemClasses())
+local TRADE_GOODS            = AUCTION_CATEGORY_TRADE_GOODS
 
 local cache = setmetatable({}, { __mode = "kv" }) -- weak table to enable garbage collection
 namespace.cache = cache -- so it can be wiped when an option changes

--- a/ItemTooltipCleaner.toc
+++ b/ItemTooltipCleaner.toc
@@ -1,4 +1,4 @@
-## Interface: 60100
+## Interface: 70000
 ## Version: @project-version@
 
 ## Title: Item Tooltip Cleaner


### PR DESCRIPTION
The only changes needed for 7.0.3 support is removing a call to the deprecated GetAuctionItemClasses function. The category name is instead pulled from the localised strings.

Also updates the version number in the toc
